### PR TITLE
✨ Adds Agenda domain with content strip

### DIFF
--- a/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
+++ b/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
@@ -25,6 +25,8 @@ use Filament\Tables\Actions\ForceDeleteBulkAction;
 use Filament\Tables\Actions\RestoreBulkAction;
 use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -167,7 +169,18 @@ class AgendaItemResource extends Resource
                     ->label('Gewijzigd op')
                     ->since(),                
             ])
-            ->heading('Agenda items')
+            ->heading('Agendapunten')
+            ->filters([
+                SelectFilter::make('language_id')
+                    ->relationship('language', 'name')
+                    ->label('Taal'),
+
+                SelectFilter::make('translated_from_id')
+                    ->options(AgendaItem::query()->get()->mapWithKeys(fn ($item) => [$item->id => $item->name]))
+                    ->label('Vertaling van'),
+
+                TrashedFilter::make(),
+            ])
             ->actions([
                 ActionGroup::make([
                     ActionGroup::make([

--- a/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
+++ b/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\Filament\Resources;
+
+use App\Domains\Agenda\Models\AgendaItem;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\Group;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Resources\Resource;
+use Filament\Support\Enums\FontWeight;
+use Filament\Tables\Actions\ActionGroup;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Actions\ForceDeleteBulkAction;
+use Filament\Tables\Actions\RestoreBulkAction;
+use Filament\Tables\Columns\SpatieMediaLibraryImageColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+use Made\Cms\Language\Models\Language;
+use Made\Cms\Shared\Enums\PublishingStatus;
+use Made\Cms\Shared\Filament\Actions\TranslateAction;
+
+class AgendaItemResource extends Resource
+{
+    protected static ?string $model = AgendaItem::class;
+
+    protected static ?string $slug = 'agenda-item';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Group::make()
+                    ->schema([
+
+                        Section::make()
+                            ->schema([
+                                TextInput::make('name')
+                                    ->label('Naam')
+                                    ->required(),
+
+                                DatePicker::make('start_date')
+                                    ->label('Startdatum')
+                                    ->helperText('De datum waarop het evenment / het agendapunt plaats vind en/of start.')
+                                    ->required()
+                                    ->default(now()),
+
+                                DatePicker::make('end_date')
+                                    ->label('Einddatum')
+                                    ->helperText('Tot wanneer het agendapunt loopt.')
+                                    ->default(now()),
+
+                                RichEditor::make('description')
+                                    ->label('Inhoud'),
+
+                                SpatieMediaLibraryFileUpload::make('image')
+                                    ->collection('image')
+                                    ->image()
+                                    ->imageEditor(),
+                            ]),
+
+                        ])
+                        ->columnSpan(['lg' => 2]),
+
+                Group::make()
+                    ->schema([
+
+                        Section::make()
+                            ->schema([
+
+                                Select::make('status')
+                                    ->label('Status')
+                                    ->helperText(
+                                        'Deze status van het agendapunt geeft aan waarvoor het 
+                                        agendapunt gebruikt kan worden. Zodra de status is 
+                                        ingesteld op gepubliceerd, kan elke bezoeker het 
+                                        agendapunt bekijken.'
+                                    )
+                                    ->options(PublishingStatus::options())
+                                    ->default(array_key_first(PublishingStatus::options())),
+
+                                Select::make('language')
+                                    ->relationship('language', 'name')
+                                    ->preload()
+                                    ->default(
+                                        Language::query()
+                                            ->default()
+                                            ->first()
+                                            ->id
+                                    )
+                                    ->label('Taal')
+                                    ->helperText('De taal van de inhoud van het agendapunt.'),
+
+                                Select::make('translated_from_id')
+                                    ->label('Vertaling van')
+                                    ->disabled()
+                                    ->relationship('translatedFrom', 'name')
+                                    ->helperText('Dit agendapunt is een vertaling van het hierboven geselecteerde agendapunt. Dit is niet te wijzigen.')
+                                    ->visible(fn (Get $get) => $get('translated_from_id') !== null),
+
+                            ]),
+
+                    ]),
+            ])
+            ->columns(3);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                SpatieMediaLibraryImageColumn::make('image')
+                    ->label('Afbeelding')
+                    ->collection('image')
+                    ->conversion('preview')
+                    ->circular(),
+                    
+                TextColumn::make('start_date')
+                    ->label('Start datum')
+                    ->sortable()
+                    ->date(),
+
+                TextColumn::make('end_date')
+                    ->label('Eind datum')
+                    ->sortable()
+                    ->date(),
+
+                TextColumn::make('name')
+                    ->label('Naam')
+                    ->weight(FontWeight::Bold)
+                    ->searchable()
+                    ->sortable(),
+
+                SpatieMediaLibraryImageColumn::make('language.flag')
+                    ->collection('flag')
+                    ->label('Taal')
+                    ->size(20)
+                    ->circular(),
+
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn (PublishingStatus $state) => $state->color())
+                    ->formatStateUsing(fn (PublishingStatus $state) => $state->label()),
+
+                TextColumn::make('translatedFrom.name')
+                    ->label('Vertaling van')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('createdBy.name')
+                    ->label('Aangemaakt door'),
+
+                TextColumn::make('updated_at')
+                    ->label('Gewijzigd op')
+                    ->since(),                
+            ])
+            ->heading('Agenda items')
+            ->actions([
+                ActionGroup::make([
+                    ActionGroup::make([
+                        TranslateAction::make(),
+                        EditAction::make(),
+                    ])
+                        ->dropdown(false),
+
+                    DeleteAction::make(),
+                ]),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    RestoreBulkAction::make(),
+                    ForceDeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultPaginationPageOption(50)
+            ->defaultSort('start_date', 'desc');
+    }
+
+    /**
+     * Returns an array of page routes for the resource.
+     *
+     * @return array An associative array where keys represent page types (e.g., 'index', 'create', 'edit')
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAgendaItems::route('/'),
+            'create' => Pages\CreateAgendaItem::route('/create'),
+            'edit' => Pages\EditAgendaItem::route('/{record}/edit'),
+        ];
+    }
+
+    /**
+     * Retrieves the Eloquent query builder instance for the resource with specific global scopes removed.
+     *
+     * @return Builder The Eloquent query builder instance with modified scope behavior.
+     */
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes([
+                SoftDeletingScope::class,
+            ]);
+    }/**
+     * Retrieves the navigation label for the resource.
+     *
+     * @return string The navigation label.
+     */
+    public static function getNavigationLabel(): string
+    {
+        return 'Agenda punten';
+    }
+
+    /**
+     * Retrieves the plural label for the resource.
+     *
+     * @return string|null The plural label if defined, or null otherwise.
+     */
+    public static function getPluralLabel(): ?string
+    {
+        return 'Agenda punten';
+    }
+
+    /**
+     * Retrieves the model label for the resource.
+     *
+     * @return string The model label.
+     */
+    public static function getModelLabel(): string
+    {
+        return 'Agenda punt';
+    }
+
+    /**
+     * Retrieves the navigation group for the resource.
+     *
+     * @return string|null The navigation group if defined, or null otherwise.
+     */
+    public static function getNavigationGroup(): ?string
+    {
+        return 'Agenda';
+    }
+
+    /**
+     * Retrieves the navigation badge count for published posts.
+     *
+     * @return string|null The count of published posts as a string, or null if unavailable.
+     */
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) AgendaItem::query()->published()->count();
+    }
+}

--- a/app/Domains/Agenda/Filament/Resources/Pages/CreateAgendaItem.php
+++ b/app/Domains/Agenda/Filament/Resources/Pages/CreateAgendaItem.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\Filament\Resources\Pages;
+
+use App\Domains\Agenda\Filament\Resources\AgendaItemResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateAgendaItem extends CreateRecord
+{
+    protected static string $resource = AgendaItemResource::class;
+}

--- a/app/Domains/Agenda/Filament/Resources/Pages/EditAgendaItem.php
+++ b/app/Domains/Agenda/Filament/Resources/Pages/EditAgendaItem.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\Filament\Resources\Pages;
+
+use App\Domains\Agenda\Filament\Resources\AgendaItemResource;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\ForceDeleteAction;
+use Filament\Actions\RestoreAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditAgendaItem extends EditRecord
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+            ForceDeleteAction::make(),
+            RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Domains/Agenda/Filament/Resources/Pages/ListAgendaItems.php
+++ b/app/Domains/Agenda/Filament/Resources/Pages/ListAgendaItems.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\Filament\Resources\Pages;
+
+use App\Domains\Agenda\Filament\Resources\AgendaItemResource;
+use App\Domains\Agenda\Models\AgendaItem;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Components\Tab;
+use Filament\Resources\Pages\ListRecords;
+use Made\Cms\Shared\Enums\PublishingStatus;
+
+class ListAgendaItems extends ListRecords
+{
+    protected static string $resource = AgendaItemResource::class;
+
+    public static ?string $title = 'Overzicht';
+
+    public static ?string $breadcrumb = 'Overzicht';
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+
+    public function getTabs(): array
+    {
+        $tabs = [
+            null => Tab::make(__('made-cms::common.all'))
+                ->badge(AgendaItem::query()->count()),
+        ];
+
+        collect(PublishingStatus::cases())->each(function (PublishingStatus $status) use (&$tabs) {
+            $tabs[$status->value] = Tab::make($status->label())
+                ->modifyQueryUsing(fn ($query) => $query->where('status', $status->value))
+                ->badge(
+                    AgendaItem::query()
+                        ->where('status', $status->value)
+                        ->count()
+                );
+        });
+
+        if (count($tabs) <= 1) {
+            return [];
+        }
+
+        return $tabs;
+    }
+}

--- a/app/Domains/Agenda/Models/AgendaItem.php
+++ b/app/Domains/Agenda/Models/AgendaItem.php
@@ -7,7 +7,6 @@ namespace App\Domains\Agenda\Models;
 use App\Domains\Agenda\QueryBuilders\AgendaItemQueryBuilder;
 use Database\Factories\AgendaItemFactory;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/app/Domains/Agenda/Models/AgendaItem.php
+++ b/app/Domains/Agenda/Models/AgendaItem.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\Models;
+
+use App\Domains\Agenda\QueryBuilders\AgendaItemQueryBuilder;
+use Database\Factories\AgendaItemFactory;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Made\Cms\Language\Models\Language;
+use Made\Cms\Models\User;
+use Made\Cms\Shared\Contracts\DefinesCreatedByContract;
+use Made\Cms\Shared\Observers\CreatedByDefiningObserver;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Illuminate\Support\Carbon;
+use Made\Cms\Shared\Enums\PublishingStatus;
+
+/**
+ * @property-read int $id
+ * @property string $name
+ * @property int|null $language_id
+ * @property int|null $translated_from_id
+ * @property string $status
+ * @property string $description
+ * @property Carbon $start_date
+ * @property Carbon $end_date
+ * @property int $created_by
+ * @property-read Carbon $created_at
+ * @property-read Carbon $updated_at
+ * @property-read Carbon|null $deleted_at
+ */
+#[ObservedBy([CreatedByDefiningObserver::class])]
+class AgendaItem extends Model implements DefinesCreatedByContract, HasMedia
+{
+    use InteractsWithMedia;
+    use SoftDeletes;
+    use HasFactory;
+
+    protected $casts = [
+        'id' => 'integer',
+        'language_id' => 'integer',
+        'translated_from_id' => 'integer',
+        'name' => 'string',
+        'start_date' => 'date',
+        'end_date' => 'date',
+        'status' => PublishingStatus::class,
+        'description' => 'string',
+        'created_by' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'deleted_at' => 'datetime',
+    ];
+
+    protected $fillable = [
+        'language_id',
+        'translated_from_id',
+        'name',
+        'description',
+        'start_date',
+        'end_date',
+        'status',
+        'created_by'
+    ];
+
+    public function translatedFrom(): BelongsTo
+    {
+        return $this->belongsTo(
+            related: AgendaItem::class,
+            foreignKey: 'translated_from_id',
+        );
+    }
+
+    public function translations(): HasMany
+    {
+        return $this->hasMany(
+            related: AgendaItem::class,
+            foreignKey: 'translated_from_id',
+        );
+    }
+
+    public function language(): BelongsTo
+    {
+        return $this->belongsTo(
+            related: Language::class,
+            foreignKey: 'language_id',
+            ownerKey: 'id',
+        );
+    }
+
+    /**
+     * Defines the relationship between this model and the User model.
+     *
+     * This method establishes a "belongs to" relationship, indicating that this model is associated with an instance of the User model through the 'author' foreign key.
+     *
+     * @return BelongsTo The relationship instance between this model and the User model.
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+    
+    /**
+     * Registers media collections for the model.
+     */
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('image');
+    }
+
+    /**
+     * Registers media conversions for the model, defining transformation settings for the media.
+     *
+     * @param  Media|null  $media  An optional Media instance to which the conversions apply.
+     * @return void No return value.
+     */
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        $this->addMediaConversion('preview')
+            ->width(300)
+            ->height(300)
+            ->sharpen(10);
+    }
+
+    protected static function newFactory(): AgendaItemFactory
+    {
+        return AgendaItemFactory::new();
+    }
+
+    public function newEloquentBuilder($query): AgendaItemQueryBuilder
+    {
+        return new AgendaItemQueryBuilder($query);
+    }
+}

--- a/app/Domains/Agenda/QueryBuilders/AgendaItemQueryBuilder.php
+++ b/app/Domains/Agenda/QueryBuilders/AgendaItemQueryBuilder.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domains\Agenda\QueryBuilders;
+
+use Illuminate\Database\Eloquent\Builder;
+use Made\Cms\Shared\QueryBuilders\HasPublishingStatusColumn;
+
+class AgendaItemQueryBuilder extends Builder
+{
+    use HasPublishingStatusColumn;
+}

--- a/app/Strips/AgendaStrip.php
+++ b/app/Strips/AgendaStrip.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Strips;
+
+use App\Domains\Agenda\Models\AgendaItem;
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Contracts\View\View;
+use Made\Cms\Filament\Builder\ContentStrip;
+
+class AgendaStrip implements ContentStrip
+{
+    public static function id(): string
+    {
+        return 'agenda-strip';
+    }
+
+    public static function render(array $attributes = []): View
+    {
+        $attributes['live'] = true;
+
+        $items = AgendaItem::query()
+            ->published()
+            ->orderBy('start_date', 'DESC')
+            ->orderBy('end_date', 'DESC')
+            ->get();
+        $grouped = $items->groupBy(fn (AgendaItem $item): string => $item->start_date->format('Y'));
+
+        $attributes['items'] = $grouped;
+
+        return view('strips.' . self::id(), $attributes);
+    }
+
+    public static function block(string $context = 'form'): Block
+    {
+        return Block::make(self::id())
+            ->label('Agenda overzicht')
+            ->icon('heroicon-s-calendar')
+            ->schema([
+                TextInput::make('title')
+                    ->label('Titel'),
+            ]);
+    }
+}

--- a/app/View/Components/Calendar/OverviewItem.php
+++ b/app/View/Components/Calendar/OverviewItem.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\View\Components\Calendar;
+
+use App\Domains\Agenda\Models\AgendaItem;
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+class OverviewItem extends Component
+{
+    /**
+     * Create a new component instance.
+     */
+    public function __construct(
+        public readonly AgendaItem $item,
+    )
+    {
+        //
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View|Closure|string
+    {
+        return view('components.calendar.overview-item');
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -3727,16 +3727,16 @@
         },
         {
             "name": "made-foryou/cms",
-            "version": "0.15.5",
+            "version": "0.15.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/made-foryou/cms.git",
-                "reference": "eb16058362b648eac26721534df2e16e60d16009"
+                "reference": "a75269325acdc57522956d2623fcf5df1a42f044"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/made-foryou/cms/zipball/eb16058362b648eac26721534df2e16e60d16009",
-                "reference": "eb16058362b648eac26721534df2e16e60d16009",
+                "url": "https://api.github.com/repos/made-foryou/cms/zipball/a75269325acdc57522956d2623fcf5df1a42f044",
+                "reference": "a75269325acdc57522956d2623fcf5df1a42f044",
                 "shasum": ""
             },
             "require": {
@@ -3831,7 +3831,7 @@
                     "url": "https://github.com/made-foryou"
                 }
             ],
-            "time": "2025-05-19T06:25:04+00:00"
+            "time": "2025-05-19T13:31:26+00:00"
         },
         {
             "name": "maennchen/zipstream-php",

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -149,6 +149,7 @@ return [
              */
             \Made\Cms\Page\Models\Page::class => [
                 Strips\PageFillableContentStrip::class,
+                Strips\AgendaStrip::class,
             ],
 
             /**

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -2,9 +2,11 @@
 
 // config for Made/Cms
 
+use App\Domains\Agenda\Filament\Resources\AgendaItemResource;
 use App\Domains\Website\Settings\WebsiteSettings;
 use App\Models\WebsiteSetting;
 use App\Strips;
+use Filament\Navigation\NavigationGroup;
 
 return [
 
@@ -55,9 +57,19 @@ return [
          */
         'default' => true,
 
-        'resources' => [],
+        'resources' => [
+            AgendaItemResource::class,
+        ],
 
         'pages' => [],
+
+        'plugins' => [],
+
+        'navigation_groups' => [
+            NavigationGroup::make()
+                ->label('Agenda')
+                ->icon('heroicon-o-calendar'),
+        ]
 
     ],
 

--- a/database/factories/AgendaItemFactory.php
+++ b/database/factories/AgendaItemFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Domains\Agenda\Models\AgendaItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Made\Cms\Language\Models\Language;
+use Made\Cms\Models\User;
+use Made\Cms\Shared\Enums\PublishingStatus;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\AgendaItem>
+ */
+class AgendaItemFactory extends Factory
+{
+    protected $model = AgendaItem::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->title,
+            'language_id' => Language::factory(),
+            'status' => PublishingStatus::Draft->value,
+            'start_date' => $this->faker->date(),
+            'description' => $this->faker->paragraphs(3, true),
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function draft(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => PublishingStatus::Draft->value,
+            ];
+        });
+    }
+
+    public function published(): Factory
+    {
+        return $this->state(function (array $attributes) {
+            return [
+                'status' => PublishingStatus::Published->value,
+            ];
+        });
+    }
+}

--- a/database/migrations/2025_05_19_1351114_create_agenda_items_table.php
+++ b/database/migrations/2025_05_19_1351114_create_agenda_items_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Made\Cms\Shared\Database\HasDatabaseTablePrefix;
+use Made\Cms\Shared\Enums\PublishingStatus;
+
+return new class extends Migration
+{
+    use HasDatabaseTablePrefix;
+
+    public function up(): void
+    {
+        Schema::create('agenda_items', function (Blueprint $table) {
+            $table->id();
+
+            $table->string('name');
+
+            $table->foreignId('language_id')
+                    ->nullable()
+                    ->references('id')
+                    ->on($this->prefixTableName('languages'))
+                    ->nullOnDelete();
+
+            $table->string('status')
+                    ->default(
+                        PublishingStatus::Draft->value
+                    );
+
+            $table->text('description');
+
+            $table->date('start_date')
+                ->default(now());
+
+            $table->date('end_date')
+                ->nullable();
+
+            /**
+             * Filled as soon as the model is saved. This tracks who
+             * modified/created this part.
+             */
+            $table->foreignId('created_by')
+                ->references('id')
+                ->on($this->prefixTableName('users'))
+                ->restrictOnDelete();
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+        
+        Schema::table(
+            table: 'agenda_items',
+            callback: function (Blueprint $table) {
+                $table->foreignId('translated_from_id')
+                    ->nullable()
+                    ->after('language_id')
+                    ->references('id')
+                    ->on('agenda_items')
+                    ->nullOnDelete();
+            }
+        );
+    }
+};

--- a/database/migrations/2025_05_19_1351114_create_agenda_items_table.php
+++ b/database/migrations/2025_05_19_1351114_create_agenda_items_table.php
@@ -28,7 +28,8 @@ return new class extends Migration
                         PublishingStatus::Draft->value
                     );
 
-            $table->text('description');
+            $table->text('description')
+                ->nullable();
 
             $table->date('start_date')
                 ->default(now());

--- a/resources/views/components/calendar/overview-item.blade.php
+++ b/resources/views/components/calendar/overview-item.blade.php
@@ -1,0 +1,31 @@
+<div {{ $attributes->merge(['class' => 'block bg-white rounded-lg overflow-hidden flex flex-col lg:flex-row justify-start items-stretch']) }}>
+    
+    <div class="lg:w-2/3 order-2 lg:order-1 py-8 px-6 lg:py-13 lg:px-12">
+
+        <span class="block uppercase text-primary-500 font-sans text-sm">
+            {{ $item->start_date->translatedFormat('d F Y') }}
+
+        @if (!empty($item->end_date))
+        
+            tot en met {{ $item->end_date->translatedFormat('d F Y') }}
+
+        @endif
+
+        </span>
+
+        <span class="block mt-2 text-black font-sans tracking-wide text-lg lg:text-xl">
+            {{ $item->name }}
+        </span>
+
+        <div>
+            {!! str($item->description)->sanitizeHtml() !!}
+        </div>
+
+    </div>
+    <div class="lg:w-1/3 order-1 lg:order-2">
+        <figure class="w-full h-full">
+            {{ $item->getFirstMedia('image')  }}
+        </figure>
+    </div>
+
+</div>

--- a/resources/views/strips/agenda-strip.blade.php
+++ b/resources/views/strips/agenda-strip.blade.php
@@ -1,0 +1,38 @@
+<section
+    class="relative
+           w-full"
+>
+    <x-container class="flex flex-col justify-center items-center w-full border-b border-secondary-100 py-12 lg:py-18 max-w-6xl">
+
+        <span
+            class="block
+                   font-sans tracking-wide text-black font-semibold text-2xl lg:text-4xl text-center"
+            data-highlightable
+        >
+            {{ $title }}
+        </span>
+
+    </x-container>
+</section>
+<section class="relative w-full pb-25">
+    <x-container class="max-w-6xl py-6 lg:py-8">
+
+    @foreach ($items as $year => $entries)
+
+        <span class="text-black font-sans block tracking-wide font-semibold text-xl lg:text-2xl">
+            {{ $year }}
+        </span>
+        <div class="mt-7 flex flex-col gap-6">
+
+        @foreach ($entries as $entry)
+        
+            <x-calendar.overview-item :item="$entry" />
+
+        @endforeach
+
+        </div>
+
+    @endforeach
+
+    </x-container>
+</section>


### PR DESCRIPTION
This pull request introduces the Agenda domain with a Filament resource for managing agenda items.

Key features include:
- Creates an AgendaItem model and resource
- Implements a content strip to display agenda items on pages
- Adds filters to the AgendaItemResource table for improved management

This enhancement provides a structured way to manage and display events on the website.