### PR TITLE
✨ Adds blocks content strip

### DIFF
--- a/app/Strips/BlocksContentStrip.php
+++ b/app/Strips/BlocksContentStrip.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Strips;
+
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms;
+use Illuminate\Contracts\View\View;
+use Made\Cms\Filament\Builder\ContentStrip;
+
+class BlocksContentStrip implements ContentStrip
+{
+    public static function id(): string
+    {
+        return "blocks-content-strip";
+    }
+
+    public static function render(array $attributes = []): View
+    {
+        $attributes["live"] = true;
+
+        return view("strips." . self::id(), $attributes);
+    }
+
+    public static function block(string $context = "form"): Block
+    {
+        return Block::make(self::id())
+            ->label("Blokken inhoud")
+            ->icon("iconic-grid")
+            ->schema(
+                components: [
+                    Forms\Components\TextInput::make("subtitle")->label(
+                        "Subtitel"
+                    ),
+
+                    Forms\Components\RichEditor::make("content")->label(
+                        "inhoud"
+                    ),
+
+                    Forms\Components\Repeater::make("items")
+                        ->label("Blokken")
+                        ->addActionLabel("Nieuw blok toevoegen")
+                        ->schema([
+                            Forms\Components\FileUpload::make("image")
+                                ->image()
+                                ->label("Afbeelding")
+                                ->imageEditor()
+                                ->imageEditorAspectRatios(["35:24"])
+                                ->preserveFilenames(),
+
+                            Forms\Components\TextInput::make("subtitle")->label(
+                                "Subtitel"
+                            ),
+
+                            Forms\Components\TextInput::make("title")->label(
+                                "Titel"
+                            ),
+
+                            Forms\Components\RichEditor::make("content")->label(
+                                "Inhoud"
+                            ),
+                        ])
+                        ->grid([
+                            "default" => 1,
+                            "md" => 3,
+                        ]),
+                ]
+            );
+    }
+}

--- a/app/Strips/CoreValuesStrip.php
+++ b/app/Strips/CoreValuesStrip.php
@@ -48,17 +48,26 @@ class CoreValuesStrip implements ContentStrip
 
                     RichEditor::make("title")->label("Titel"),
 
-                    Repeater::make("values")->schema(
-                        components: [
-                            Select::make("icon")
-                                ->options(self::iconOptions())
-                                ->label("Icoon"),
+                    Repeater::make("values")
+                        ->label("Onderdelen")
+                        ->addActionLabel("Nieuw onderdeel toevoegen")
+                        ->schema(
+                            components: [
+                                Select::make("icon")
+                                    ->options(self::iconOptions())
+                                    ->label("Icoon"),
 
-                            TextInput::make("title")->label("Titel"),
+                                TextInput::make("title")->label("Titel"),
 
-                            RichEditor::make("content")->label("Omschrijving"),
-                        ]
-                    ),
+                                RichEditor::make("content")->label(
+                                    "Omschrijving"
+                                ),
+                            ]
+                        )
+                        ->grid([
+                            "default" => 1,
+                            "md" => 3,
+                        ]),
                 ]
             );
     }

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -134,6 +134,7 @@ return [
                 Strips\LargeSmallColumnStrip::class,
                 Strips\TextStrip::class,
                 Strips\CoreValuesStrip::class,
+                Strips\BlocksContentStrip::class,
             ],
 
             /**

--- a/resources/views/strips/blocks-content-strip.blade.php
+++ b/resources/views/strips/blocks-content-strip.blade.php
@@ -1,0 +1,64 @@
+@php
+    $live = $live ?? false;
+@endphp
+
+<section
+    class="relative
+           py-12 w-full
+           bg-secondary-500
+           lg:py-18"
+>
+    <x-container
+        class="max-w-6xl w-full"
+    >
+        <div class="text-center mb-15">
+            <span
+                class="block
+                    border-b border-secondary-500
+                    text-xs text-primary-500 font-sans tracking-wide uppercase leading-8.5
+                    md:text-sm"
+            >
+                {{ $subtitle }}
+            </span>
+            <div
+                class="text-center prose mx-auto"
+                data-highlightable
+            >
+                {!! str($content)->sanitizeHtml() !!}
+            </div>
+        </div>
+
+        <div class="grid md:grid-cols-3 gap-6 mt-7">
+
+            @foreach ($items as $item)
+
+            @php
+                $image = $live ? asset("storage/{$item['image']}") : asset('storage/' . array_pop($item['image']));
+            @endphp
+
+            <div>
+                <img src="{{ $image }}" alt="{{ $item['title'] ?? '' }}" class="aspect-35/24 max-h-[240px] w-full object-cover object-center rounded-lg mb-7" />
+
+                @if (isset($item['subtitle']) && strlen($item['subtitle']) > 0)
+                <span
+                    class="block text-xs text-primary-500 font-sans tracking-wide uppercase leading-8.5
+                        md:text-sm"
+                >
+                    {{ $item['subtitle'] }}
+                </span>
+                @endif
+
+                <h3 class="text-lg tracking-wide leading-8.5 mb-4">
+                    {{ $item['title'] }}
+                </h3>
+                <div class="prose-sm">
+                    {!! str($item['content'])->sanitizeHtml() !!}
+                </div>
+            </div>
+
+            @endforeach
+
+        </div>
+
+    </x-container>
+</section>


### PR DESCRIPTION
Adds a new content strip type that allows users to create flexible layouts with blocks of content, including images, titles, subtitles, and rich text.

- Introduces a new "Blocks Content Strip" accessible within the CMS.
- Allows editors to define a subtitle and main content area for the strip.
- Enables the creation of repeatable blocks, each with an image, subtitle, title, and content.
- Includes image editing capabilities for the blocks with predefined aspect ratios.
- Implements frontend rendering for the new content strip.