### PR TITLE
✨ Adds Year Report functionality to CMS

### DIFF
--- a/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
+++ b/app/Domains/Agenda/Filament/Resources/AgendaItemResource.php
@@ -38,7 +38,7 @@ class AgendaItemResource extends Resource
 {
     protected static ?string $model = AgendaItem::class;
 
-    protected static ?string $slug = 'agenda-item';
+    protected static ?string $slug = "agenda-item";
 
     public static function form(Form $form): Form
     {
@@ -46,75 +46,71 @@ class AgendaItemResource extends Resource
             ->schema([
                 Group::make()
                     ->schema([
+                        Section::make()->schema([
+                            TextInput::make("name")->label("Naam")->required(),
 
-                        Section::make()
-                            ->schema([
-                                TextInput::make('name')
-                                    ->label('Naam')
-                                    ->required(),
+                            DatePicker::make("start_date")
+                                ->label("Startdatum")
+                                ->helperText(
+                                    "De datum waarop het evenment / het agendapunt plaats vind en/of start."
+                                )
+                                ->required()
+                                ->default(now()),
 
-                                DatePicker::make('start_date')
-                                    ->label('Startdatum')
-                                    ->helperText('De datum waarop het evenment / het agendapunt plaats vind en/of start.')
-                                    ->required()
-                                    ->default(now()),
+                            DatePicker::make("end_date")
+                                ->label("Einddatum")
+                                ->helperText(
+                                    "Tot wanneer het agendapunt loopt."
+                                )
+                                ->default(now()),
 
-                                DatePicker::make('end_date')
-                                    ->label('Einddatum')
-                                    ->helperText('Tot wanneer het agendapunt loopt.')
-                                    ->default(now()),
+                            RichEditor::make("description")->label("Inhoud"),
 
-                                RichEditor::make('description')
-                                    ->label('Inhoud'),
+                            SpatieMediaLibraryFileUpload::make("image")
+                                ->collection("image")
+                                ->image()
+                                ->imageEditor(),
+                        ]),
+                    ])
+                    ->columnSpan(["lg" => 2]),
 
-                                SpatieMediaLibraryFileUpload::make('image')
-                                    ->collection('image')
-                                    ->image()
-                                    ->imageEditor(),
-                            ]),
-
-                        ])
-                        ->columnSpan(['lg' => 2]),
-
-                Group::make()
-                    ->schema([
-
-                        Section::make()
-                            ->schema([
-
-                                Select::make('status')
-                                    ->label('Status')
-                                    ->helperText(
-                                        'Deze status van het agendapunt geeft aan waarvoor het 
-                                        agendapunt gebruikt kan worden. Zodra de status is 
-                                        ingesteld op gepubliceerd, kan elke bezoeker het 
+                Group::make()->schema([
+                    Section::make()->schema([
+                        Select::make("status")
+                            ->label("Status")
+                            ->helperText(
+                                'Deze status van het agendapunt geeft aan waarvoor het
+                                        agendapunt gebruikt kan worden. Zodra de status is
+                                        ingesteld op gepubliceerd, kan elke bezoeker het
                                         agendapunt bekijken.'
-                                    )
-                                    ->options(PublishingStatus::options())
-                                    ->default(array_key_first(PublishingStatus::options())),
+                            )
+                            ->options(PublishingStatus::options())
+                            ->default(
+                                array_key_first(PublishingStatus::options())
+                            ),
 
-                                Select::make('language')
-                                    ->relationship('language', 'name')
-                                    ->preload()
-                                    ->default(
-                                        Language::query()
-                                            ->default()
-                                            ->first()
-                                            ->id
-                                    )
-                                    ->label('Taal')
-                                    ->helperText('De taal van de inhoud van het agendapunt.'),
+                        Select::make("language")
+                            ->relationship("language", "name")
+                            ->preload()
+                            ->default(Language::query()->default()->first()->id)
+                            ->label("Taal")
+                            ->helperText(
+                                "De taal van de inhoud van het agendapunt."
+                            ),
 
-                                Select::make('translated_from_id')
-                                    ->label('Vertaling van')
-                                    ->disabled()
-                                    ->relationship('translatedFrom', 'name')
-                                    ->helperText('Dit agendapunt is een vertaling van het hierboven geselecteerde agendapunt. Dit is niet te wijzigen.')
-                                    ->visible(fn (Get $get) => $get('translated_from_id') !== null),
-
-                            ]),
-
+                        Select::make("translated_from_id")
+                            ->label("Vertaling van")
+                            ->disabled()
+                            ->relationship("translatedFrom", "name")
+                            ->helperText(
+                                "Dit agendapunt is een vertaling van het hierboven geselecteerde agendapunt. Dit is niet te wijzigen."
+                            )
+                            ->visible(
+                                fn(Get $get) => $get("translated_from_id") !==
+                                    null
+                            ),
                     ]),
+                ]),
             ])
             ->columns(3);
     }
@@ -123,61 +119,66 @@ class AgendaItemResource extends Resource
     {
         return $table
             ->columns([
-                SpatieMediaLibraryImageColumn::make('image')
-                    ->label('Afbeelding')
-                    ->collection('image')
-                    ->conversion('preview')
+                SpatieMediaLibraryImageColumn::make("image")
+                    ->label("Afbeelding")
+                    ->collection("image")
+                    ->conversion("preview")
                     ->circular(),
-                    
-                TextColumn::make('start_date')
-                    ->label('Start datum')
+
+                TextColumn::make("start_date")
+                    ->label("Start datum")
                     ->sortable()
                     ->date(),
 
-                TextColumn::make('end_date')
-                    ->label('Eind datum')
+                TextColumn::make("end_date")
+                    ->label("Eind datum")
                     ->sortable()
                     ->date(),
 
-                TextColumn::make('name')
-                    ->label('Naam')
+                TextColumn::make("name")
+                    ->label("Naam")
                     ->weight(FontWeight::Bold)
                     ->searchable()
                     ->sortable(),
 
-                SpatieMediaLibraryImageColumn::make('language.flag')
-                    ->collection('flag')
-                    ->label('Taal')
+                SpatieMediaLibraryImageColumn::make("language.flag")
+                    ->collection("flag")
+                    ->label("Taal")
                     ->size(20)
                     ->circular(),
 
-                TextColumn::make('status')
-                    ->label('Status')
+                TextColumn::make("status")
+                    ->label("Status")
                     ->badge()
-                    ->color(fn (PublishingStatus $state) => $state->color())
-                    ->formatStateUsing(fn (PublishingStatus $state) => $state->label()),
+                    ->color(fn(PublishingStatus $state) => $state->color())
+                    ->formatStateUsing(
+                        fn(PublishingStatus $state) => $state->label()
+                    ),
 
-                TextColumn::make('translatedFrom.name')
-                    ->label('Vertaling van')
+                TextColumn::make("translatedFrom.name")
+                    ->label("Vertaling van")
                     ->searchable()
                     ->sortable(),
 
-                TextColumn::make('createdBy.name')
-                    ->label('Aangemaakt door'),
+                TextColumn::make("createdBy.name")->label("Aangemaakt door"),
 
-                TextColumn::make('updated_at')
-                    ->label('Gewijzigd op')
-                    ->since(),                
+                TextColumn::make("updated_at")->label("Gewijzigd op")->since(),
             ])
-            ->heading('Agendapunten')
+            ->heading("Agendapunten")
             ->filters([
-                SelectFilter::make('language_id')
-                    ->relationship('language', 'name')
-                    ->label('Taal'),
+                SelectFilter::make("language_id")
+                    ->relationship("language", "name")
+                    ->label("Taal"),
 
-                SelectFilter::make('translated_from_id')
-                    ->options(AgendaItem::query()->get()->mapWithKeys(fn ($item) => [$item->id => $item->name]))
-                    ->label('Vertaling van'),
+                SelectFilter::make("translated_from_id")
+                    ->options(
+                        AgendaItem::query()
+                            ->get()
+                            ->mapWithKeys(
+                                fn($item) => [$item->id => $item->name]
+                            )
+                    )
+                    ->label("Vertaling van"),
 
                 TrashedFilter::make(),
             ])
@@ -186,8 +187,7 @@ class AgendaItemResource extends Resource
                     ActionGroup::make([
                         TranslateAction::make(),
                         EditAction::make(),
-                    ])
-                        ->dropdown(false),
+                    ])->dropdown(false),
 
                     DeleteAction::make(),
                 ]),
@@ -200,7 +200,7 @@ class AgendaItemResource extends Resource
                 ]),
             ])
             ->defaultPaginationPageOption(50)
-            ->defaultSort('start_date', 'desc');
+            ->defaultSort("start_date", "desc");
     }
 
     /**
@@ -211,9 +211,9 @@ class AgendaItemResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => Pages\ListAgendaItems::route('/'),
-            'create' => Pages\CreateAgendaItem::route('/create'),
-            'edit' => Pages\EditAgendaItem::route('/{record}/edit'),
+            "index" => Pages\ListAgendaItems::route("/"),
+            "create" => Pages\CreateAgendaItem::route("/create"),
+            "edit" => Pages\EditAgendaItem::route("/{record}/edit"),
         ];
     }
 
@@ -224,18 +224,19 @@ class AgendaItemResource extends Resource
      */
     public static function getEloquentQuery(): Builder
     {
-        return parent::getEloquentQuery()
-            ->withoutGlobalScopes([
-                SoftDeletingScope::class,
-            ]);
-    }/**
+        return parent::getEloquentQuery()->withoutGlobalScopes([
+            SoftDeletingScope::class,
+        ]);
+    }
+
+    /**
      * Retrieves the navigation label for the resource.
      *
      * @return string The navigation label.
      */
     public static function getNavigationLabel(): string
     {
-        return 'Agenda punten';
+        return "Agenda punten";
     }
 
     /**
@@ -245,7 +246,7 @@ class AgendaItemResource extends Resource
      */
     public static function getPluralLabel(): ?string
     {
-        return 'Agenda punten';
+        return "Agenda punten";
     }
 
     /**
@@ -255,7 +256,7 @@ class AgendaItemResource extends Resource
      */
     public static function getModelLabel(): string
     {
-        return 'Agenda punt';
+        return "Agenda punt";
     }
 
     /**
@@ -265,7 +266,7 @@ class AgendaItemResource extends Resource
      */
     public static function getNavigationGroup(): ?string
     {
-        return 'Agenda';
+        return "Agenda";
     }
 
     /**

--- a/app/Filament/Resources/YearReportResource.php
+++ b/app/Filament/Resources/YearReportResource.php
@@ -38,6 +38,7 @@ class YearReportResource extends Resource
 
                     Forms\Components\FileUpload::make("file")
                         ->label("Bestand")
+                        ->preserveFilenames()
                         ->required(),
                 ]),
             ]),

--- a/app/Filament/Resources/YearReportResource.php
+++ b/app/Filament/Resources/YearReportResource.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\YearReportResource\Pages;
+use App\Filament\Resources\YearReportResource\RelationManagers;
+use App\Models\YearReport;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\SoftDeletingScope;
+
+class YearReportResource extends Resource
+{
+    protected static ?string $model = YearReport::class;
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Group::make()->schema([
+                Forms\Components\Section::make()->schema([
+                    Forms\Components\DatePicker::make("year")
+                        ->format("Y")
+                        ->native(false)
+                        ->displayFormat("Y")
+                        ->required(),
+
+                    Forms\Components\TextInput::make("title")
+                        ->required()
+                        ->maxLength(255),
+
+                    Forms\Components\Textarea::make(
+                        "description"
+                    )->columnSpanFull(),
+
+                    Forms\Components\FileUpload::make("file")
+                        ->label("Bestand")
+                        ->required(),
+                ]),
+            ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make("year"),
+                Tables\Columns\TextColumn::make("title")->searchable(),
+                Tables\Columns\TextColumn::make("file")->searchable(),
+                Tables\Columns\TextColumn::make("created_at")
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make("updated_at")
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make("deleted_at")
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([Tables\Filters\TrashedFilter::make()])
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                    Tables\Actions\ForceDeleteBulkAction::make(),
+                    Tables\Actions\RestoreBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+                //
+            ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            "index" => Pages\ListYearReports::route("/"),
+            "create" => Pages\CreateYearReport::route("/create"),
+            "view" => Pages\ViewYearReport::route("/{record}"),
+            "edit" => Pages\EditYearReport::route("/{record}/edit"),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->withoutGlobalScopes([
+            SoftDeletingScope::class,
+        ]);
+    }
+
+    /**
+     * Retrieves the navigation label for the resource.
+     *
+     * @return string The navigation label.
+     */
+    public static function getNavigationLabel(): string
+    {
+        return "Jaarverslagen";
+    }
+
+    /**
+     * Retrieves the plural label for the resource.
+     *
+     * @return string|null The plural label if defined, or null otherwise.
+     */
+    public static function getPluralLabel(): ?string
+    {
+        return "Jaarverslagen";
+    }
+
+    /**
+     * Retrieves the model label for the resource.
+     *
+     * @return string The model label.
+     */
+    public static function getModelLabel(): string
+    {
+        return "Jaarverslag";
+    }
+
+    /**
+     * Retrieves the navigation group for the resource.
+     *
+     * @return string|null The navigation group if defined, or null otherwise.
+     */
+    public static function getNavigationGroup(): ?string
+    {
+        return "Organisatie";
+    }
+
+    /**
+     * Retrieves the navigation badge count for published posts.
+     *
+     * @return string|null The count of published posts as a string, or null if unavailable.
+     */
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) YearReport::query()->count();
+    }
+}

--- a/app/Filament/Resources/YearReportResource/Pages/CreateYearReport.php
+++ b/app/Filament/Resources/YearReportResource/Pages/CreateYearReport.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\YearReportResource\Pages;
+
+use App\Filament\Resources\YearReportResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateYearReport extends CreateRecord
+{
+    protected static string $resource = YearReportResource::class;
+}

--- a/app/Filament/Resources/YearReportResource/Pages/EditYearReport.php
+++ b/app/Filament/Resources/YearReportResource/Pages/EditYearReport.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\YearReportResource\Pages;
+
+use App\Filament\Resources\YearReportResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditYearReport extends EditRecord
+{
+    protected static string $resource = YearReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+            Actions\ForceDeleteAction::make(),
+            Actions\RestoreAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/YearReportResource/Pages/ListYearReports.php
+++ b/app/Filament/Resources/YearReportResource/Pages/ListYearReports.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\YearReportResource\Pages;
+
+use App\Filament\Resources\YearReportResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListYearReports extends ListRecords
+{
+    protected static string $resource = YearReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/YearReportResource/Pages/ViewYearReport.php
+++ b/app/Filament/Resources/YearReportResource/Pages/ViewYearReport.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\YearReportResource\Pages;
+
+use App\Filament\Resources\YearReportResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewYearReport extends ViewRecord
+{
+    protected static string $resource = YearReportResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Models/YearReport.php
+++ b/app/Models/YearReport.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property-read int $id
+ * @property Carbon $year
+ * @property string $title
+ * @property string | null $description
+ * @property string $file
+ * @property-read Carbon $created_at
+ * @property-read Carbon $updated_at
+ * @property-read Carbon | null $deleted_at
+ */
+class YearReport extends Model
+{
+    /** @use HasFactory<\Database\Factories\YearReportFactory> */
+    use HasFactory;
+    use SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = ["year", "title", "description", "file"];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            "id" => "integer",
+            "year" => "date",
+            "title" => "string",
+            "description" => "string",
+            "file" => "string",
+            "created_at" => "datetime",
+            "updated_at" => "datetime",
+            "deleted_at" => "datetime",
+        ];
+    }
+}

--- a/app/Models/YearReport.php
+++ b/app/Models/YearReport.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Number;
 
 /**
  * @property-read int $id
@@ -39,7 +42,7 @@ class YearReport extends Model
     {
         return [
             "id" => "integer",
-            "year" => "date",
+            "year" => "string",
             "title" => "string",
             "description" => "string",
             "file" => "string",
@@ -47,5 +50,14 @@ class YearReport extends Model
             "updated_at" => "datetime",
             "deleted_at" => "datetime",
         ];
+    }
+
+    public function fileSize(): Attribute
+    {
+        return new Attribute(
+            get: fn($value, array $attributes): string => Number::fileSize(
+                filesize(storage_path("app/public/{$attributes["file"]}"))
+            )
+        );
     }
 }

--- a/app/Strips/YearReportsStrip.php
+++ b/app/Strips/YearReportsStrip.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Strips;
+
+use App\Models\YearReport;
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Contracts\View\View;
+use Made\Cms\Filament\Builder\ContentStrip;
+
+class YearReportsStrip implements ContentStrip
+{
+    public static function id(): string
+    {
+        return "year-reports-strip";
+    }
+
+    public static function render(array $attributes = []): View
+    {
+        $attributes["live"] = true;
+
+        return view(
+            "strips." . self::id(),
+            array_merge($attributes, [
+                "reports" => YearReport::query()
+                    ->orderByDesc("year")
+                    ->get()
+                    ->groupBy("year"),
+            ])
+        );
+    }
+
+    public static function block(string $context = "form"): Block
+    {
+        return Block::make(self::id())
+            ->label("Jaarverslagen")
+            ->schema([
+                TextInput::make("subtitle")->label("Subtitel"),
+                TextInput::make("title")->label("titel"),
+            ]);
+    }
+}

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -139,6 +139,7 @@ return [
                 Strips\TextStrip::class,
                 Strips\CoreValuesStrip::class,
                 Strips\BlocksContentStrip::class,
+                Strips\YearReportsStrip::class,
             ],
 
             /**

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -4,6 +4,7 @@
 
 use App\Domains\Agenda\Filament\Resources\AgendaItemResource;
 use App\Domains\Website\Settings\WebsiteSettings;
+use App\Filament\Resources\YearReportResource;
 use App\Models\WebsiteSetting;
 use App\Strips;
 use Filament\Navigation\NavigationGroup;
@@ -56,7 +57,7 @@ return [
          */
         "default" => true,
 
-        "resources" => [AgendaItemResource::class],
+        "resources" => [AgendaItemResource::class, YearReportResource::class],
 
         "pages" => [],
 
@@ -66,6 +67,9 @@ return [
             NavigationGroup::make()
                 ->label("Agenda")
                 ->icon("heroicon-o-calendar"),
+            NavigationGroup::make()
+                ->label("Organisatie")
+                ->icon("heroicon-o-academic-cap"),
         ],
     ],
 

--- a/database/factories/YearReportFactory.php
+++ b/database/factories/YearReportFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\YearReport>
+ */
+class YearReportFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            "year" => $this->faker->year,
+            "title" => $this->faker->sentence,
+            "description" => $this->faker->paragraph,
+            "file" => $this->faker->file,
+        ];
+    }
+}

--- a/database/migrations/2025_06_06_132858_create_year_reports_table.php
+++ b/database/migrations/2025_06_06_132858_create_year_reports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create("year_reports", function (Blueprint $table) {
+            $table->id();
+
+            $table->year("year");
+
+            $table->string("title");
+            $table->text("description")->nullable();
+
+            $table->string("file");
+
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists("year_reports");
+    }
+};

--- a/resources/views/strips/year-reports-strip.blade.php
+++ b/resources/views/strips/year-reports-strip.blade.php
@@ -1,0 +1,85 @@
+@php
+    $live = $live ?? false;
+@endphp
+
+<section
+    class="relative
+           w-full"
+>
+    <x-container class="flex flex-col justify-center items-center w-full pt-12 lg:pt-18 max-w-6xl">
+
+        <div class="text-center mb-6">
+            <span
+                class="block
+                    border-b border-secondary-500
+                    text-xs text-primary-500 font-sans tracking-wide uppercase leading-8.5
+                    md:text-sm"
+            >
+                {{ $subtitle }}
+            </span>
+            <span
+                class="text-2xl tracking-wide font-bold"
+                data-highlightable
+            >
+                {{ $title }}
+            </span>
+        </div>
+
+    </x-container>
+</section>
+<section class="relative w-full pb-25">
+    <x-container class="max-w-6xl py-6 lg:py-8">
+
+    @foreach ($reports as $year => $entries)
+
+        <span class="text-black font-sans block tracking-wide font-semibold text-xl lg:text-2xl">
+            {{ $year }}
+        </span>
+        <div class="mt-7 flex flex-col gap-6 mb-8">
+
+        @foreach ($entries as $entry)
+
+            @php
+                $file = $live ? asset("storage/{$entry->file}") : asset('storage/' . array_pop($entry->file));
+            @endphp
+
+            <div class="bg-white rounded-lg overflow-hidden flex flex-col lg:flex-row justify-start items-stretch">
+                <div class="lg:w-2/3 order-2 lg:order-1 py-8 px-6 lg:py-13 lg:px-12">
+                    <span class="block uppercase text-primary-500 font-sans text-sm">
+                        {{ $entry->year }}
+                    </span>
+                    <span class="block mt-2 text-black font-sans tracking-wide text-lg lg:text-xl">
+                        {{ $entry->title }}
+                    </span>
+                    <div class="prose-sm mb-6">
+                        {!! str($entry->description)->sanitizeHtml() !!}
+                    </div>
+                    <ul role="list" class="divide-y divide-gray-100 rounded-md border border-gray-200">
+                        <li class="flex items-center justify-between py-4 pr-5 pl-4 text-sm/6">
+                            <div class="flex w-0 flex-1 items-center">
+                                <svg class="size-5 shrink-0 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true" data-slot="icon">
+                                    <path fill-rule="evenodd" d="M15.621 4.379a3 3 0 0 0-4.242 0l-7 7a3 3 0 0 0 4.241 4.243h.001l.497-.5a.75.75 0 0 1 1.064 1.057l-.498.501-.002.002a4.5 4.5 0 0 1-6.364-6.364l7-7a4.5 4.5 0 0 1 6.368 6.36l-3.455 3.553A2.625 2.625 0 1 1 9.52 9.52l3.45-3.451a.75.75 0 1 1 1.061 1.06l-3.45 3.451a1.125 1.125 0 0 0 1.587 1.595l3.454-3.553a3 3 0 0 0 0-4.242Z" clip-rule="evenodd" />
+                                </svg>
+                                <div class="ml-4 flex min-w-0 flex-1 gap-2">
+                                    <span class="truncate font-medium">{{ $entry->file }}</span>
+                                    <span class="shrink-0 text-gray-400">{{ $entry->fileSize }}</span>
+                                </div>
+                            </div>
+                            <div class="ml-4 shrink-0">
+                                <a href="{{ $file }}" target="_blank" class="font-medium text-primary-500 hover:text-primary-400">
+                                    Download
+                                </a>
+                            </div>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+        @endforeach
+
+        </div>
+
+    @endforeach
+
+    </x-container>
+</section>


### PR DESCRIPTION
This pull request introduces the ability to manage and display year reports within the CMS.

- Implements a new YearReport resource in Filament admin panel, allowing administrators to create, edit, and delete year reports.
- Adds a Year Reports content strip, enabling website editors to easily incorporate a list of downloadable year reports on any page.
- Refactors AgendaItemResource for code styling consistency.