### PR TITLE
Nieuwe content-strip: Cookieverklaring (Cookiebot)

### DIFF
--- a/app/Strips/CookieDeclarationStrip.php
+++ b/app/Strips/CookieDeclarationStrip.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Strips;
+
+use Filament\Forms\Components\Builder\Block;
+use Filament\Forms\Components\TextInput;
+use Illuminate\Contracts\View\View;
+use Made\Cms\Filament\Builder\ContentStrip;
+
+class CookieDeclarationStrip implements ContentStrip
+{
+    public static function id(): string
+    {
+        return 'cookie-declaration';
+    }
+
+    public static function render(array $attributes = []): View
+    {
+        $attributes['live'] = true;
+
+        return view('strips.' . self::id(), $attributes);
+    }
+
+    public static function block(string $context = 'form'): Block
+    {
+        return Block::make(self::id())
+            ->label('Cookieverklaring')
+            ->icon('heroicon-s-shield-check')
+            ->schema([
+                TextInput::make('subtitle')
+                    ->label('Subtitel')
+                    ->helperText('Optionele eyebrow boven de cookieverklaring.'),
+
+                TextInput::make('title')
+                    ->label('Titel')
+                    ->helperText('Optionele titel boven de cookieverklaring.'),
+
+                TextInput::make('url')
+                    ->label('Cookiebot URL')
+                    ->required()
+                    ->url()
+                    ->helperText('De src-URL uit de Cookiebot CookieDeclaration-embedcode, bijvoorbeeld https://consent.cookiebot.com/{id}/cd.js'),
+            ]);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "laravel/framework": "^11.31",
         "laravel/nightwatch": "^1.10",
         "laravel/tinker": "^2.9",
-        "made-foryou/cms": "^0.15",
+        "made-foryou/cms": "^0.16",
         "mailchimp/marketing": "^3.0",
         "nembie/iban-rule": "^1.0",
         "spatie/laravel-honeypot": "^4.6",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "made-foryou/mozkids-website",
     "type": "project",
     "description": "The skeleton application for the Laravel framework.",
-    "version": "1.1.3",
+    "version": "0.2.0",
     "keywords": [
         "laravel",
         "framework"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e7e9ec4cbfc4ed5621b9e1c9763ceca",
+    "content-hash": "b4a97723fe2be7788db3ea4e91807c6e",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -3879,16 +3879,16 @@
         },
         {
             "name": "made-foryou/cms",
-            "version": "0.15.12",
+            "version": "0.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/made-foryou/cms.git",
-                "reference": "3a15c6fdfb58f5f5fbf4d86ac898cfe6cc3c684f"
+                "reference": "8b9e9e9b8e76cd8ea7099cc6a7b76aaefc274acf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/made-foryou/cms/zipball/3a15c6fdfb58f5f5fbf4d86ac898cfe6cc3c684f",
-                "reference": "3a15c6fdfb58f5f5fbf4d86ac898cfe6cc3c684f",
+                "url": "https://api.github.com/repos/made-foryou/cms/zipball/8b9e9e9b8e76cd8ea7099cc6a7b76aaefc274acf",
+                "reference": "8b9e9e9b8e76cd8ea7099cc6a7b76aaefc274acf",
                 "shasum": ""
             },
             "require": {
@@ -3901,6 +3901,7 @@
                 "maatwebsite/excel": "^3.1",
                 "pboivin/filament-peek": "^2.3",
                 "php": "^8.3",
+                "spatie/laravel-data": "^4.23",
                 "spatie/laravel-package-tools": "^1.15.0"
             },
             "require-dev": {
@@ -3983,7 +3984,7 @@
                     "url": "https://github.com/made-foryou"
                 }
             ],
-            "time": "2026-02-26T13:18:48+00:00"
+            "time": "2026-06-16T09:37:47+00:00"
         },
         {
             "name": "maennchen/zipstream-php",
@@ -5079,6 +5080,70 @@
                 "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
             },
             "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/31a105931bc8ffa3a123383829772e832fd8d903",
+                "reference": "31a105931bc8ffa3a123383829772e832fd8d903",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.7"
+            },
+            "time": "2026-03-18T20:47:46+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -6429,6 +6494,90 @@
             "time": "2024-05-17T09:06:10+00:00"
         },
         {
+            "name": "spatie/laravel-data",
+            "version": "4.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/laravel-data.git",
+                "reference": "230543769c996e407fec2873930626aed7dd0d3b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/laravel-data/zipball/230543769c996e407fec2873930626aed7dd0d3b",
+                "reference": "230543769c996e407fec2873930626aed7dd0d3b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/reflection-docblock": "^5.3 || ^6.0",
+                "phpdocumentor/type-resolver": "^1.7 || ^2.0",
+                "spatie/laravel-package-tools": "^1.9.0",
+                "spatie/php-structure-discoverer": "^2.0"
+            },
+            "require-dev": {
+                "fakerphp/faker": "^1.14",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "inertiajs/inertia-laravel": "^2.0|^3.0",
+                "livewire/livewire": "^3.0|^4.0",
+                "mockery/mockery": "^1.6",
+                "nesbot/carbon": "^2.63|^3.0",
+                "orchestra/testbench": "^8.37.0|^9.16|^10.9|^11.0",
+                "pestphp/pest": "^2.36|^3.8|^4.3",
+                "pestphp/pest-plugin-laravel": "^2.4|^3.0|^4.0",
+                "pestphp/pest-plugin-livewire": "^2.1|^3.0|^4.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "spatie/invade": "^1.0",
+                "spatie/laravel-typescript-transformer": "^2.5",
+                "spatie/pest-plugin-snapshots": "^2.1",
+                "spatie/test-time": "^1.2"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\LaravelData\\LaravelDataServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\LaravelData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Create unified resources and data transfer objects",
+            "homepage": "https://github.com/spatie/laravel-data",
+            "keywords": [
+                "laravel",
+                "laravel-data",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/laravel-data/issues",
+                "source": "https://github.com/spatie/laravel-data/tree/4.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-05-08T14:41:13+00:00"
+        },
+        {
             "name": "spatie/laravel-honeypot",
             "version": "4.6.1",
             "source": {
@@ -6759,6 +6908,85 @@
                 }
             ],
             "time": "2026-02-09T15:22:32+00:00"
+        },
+        {
+            "name": "spatie/php-structure-discoverer",
+            "version": "2.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/php-structure-discoverer.git",
+                "reference": "fa2b7dae8e8a22c0306154c4b052420e054f7e2b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/php-structure-discoverer/zipball/fa2b7dae8e8a22c0306154c4b052420e054f7e2b",
+                "reference": "fa2b7dae8e8a22c0306154c4b052420e054f7e2b",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/collections": "^11.0|^12.0|^13.0",
+                "php": "^8.3",
+                "spatie/laravel-package-tools": "^1.92.7",
+                "symfony/finder": "^6.0|^7.3.5|^8.0"
+            },
+            "require-dev": {
+                "amphp/parallel": "^2.3.2",
+                "illuminate/console": "^11.0|^12.0|^13.0",
+                "nunomaduro/collision": "^7.0|^8.8.3",
+                "orchestra/testbench": "^9.5|^10.8|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.0",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.2",
+                "spatie/laravel-ray": "^1.43.1"
+            },
+            "suggest": {
+                "amphp/parallel": "When you want to use the Parallel discover worker"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Spatie\\StructureDiscoverer\\StructureDiscovererServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\StructureDiscoverer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ruben Van Assche",
+                    "email": "ruben@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Automatically discover structures within your PHP application",
+            "homepage": "https://github.com/spatie/php-structure-discoverer",
+            "keywords": [
+                "discover",
+                "laravel",
+                "php",
+                "php-structure-discoverer"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/php-structure-discoverer/issues",
+                "source": "https://github.com/spatie/php-structure-discoverer/tree/2.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/LaravelAutoDiscoverer",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-15T07:14:32+00:00"
         },
         {
             "name": "spatie/temporary-directory",
@@ -9762,6 +9990,72 @@
                 }
             ],
             "time": "2024-11-21T01:49:47+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+            },
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "packages-dev": [

--- a/config/made-cms.php
+++ b/config/made-cms.php
@@ -143,6 +143,7 @@ return [
                 Strips\TimelineStrip::class,
                 Strips\FaqStrip::class,
                 Strips\BoardMembersStrip::class,
+                Strips\CookieDeclarationStrip::class,
             ],
 
             /**

--- a/resources/views/strips/cookie-declaration.blade.php
+++ b/resources/views/strips/cookie-declaration.blade.php
@@ -1,0 +1,56 @@
+@php
+    $subtitle = $subtitle ?? null;
+    $title = $title ?? null;
+    $url = $url ?? null;
+@endphp
+
+<section class="text-strip relative
+                w-full
+                pt-3 pb-8
+                lg:pt-4 lg:pb-12
+                [&:first-child]:pt-12 lg:[&:first-child]:pt-16">
+
+    <x-container class="max-w-6xl">
+
+        @if (!empty($subtitle))
+            <span class="text-strip__eyebrow
+                         inline-flex items-center gap-2
+                         mb-4
+                         text-[10px] md:text-[11px] font-semibold uppercase tracking-[0.22em]
+                         text-primary-500"
+                  data-reveal="fade-up"
+                  style="--reveal-delay: 0ms">
+                <span class="inline-block w-1 h-1 rounded-full bg-primary-500 nav-pulse"
+                      aria-hidden="true"></span>
+                <span>{{ $subtitle }}</span>
+                <span class="ml-1 inline-block w-6 h-px
+                             bg-gradient-to-r from-primary-500/40 to-transparent"
+                      aria-hidden="true"></span>
+            </span>
+        @endif
+
+        @if (!empty($title))
+            <h1 class="text-strip__title
+                       block mb-6
+                       text-3xl lg:text-4xl
+                       text-secondary-900 font-semibold
+                       tracking-[-0.018em] leading-[1.15]
+                       text-balance"
+                data-reveal="fade-up"
+                style="--reveal-delay: {{ !empty($subtitle) ? 120 : 0 }}ms">
+                {{ $title }}
+            </h1>
+        @endif
+
+        @if (!empty($url))
+            <div class="prose max-w-none text-strip__prose
+                        text-secondary-900/82
+                        [&>p:first-child]:mt-0"
+                 data-reveal="fade-up"
+                 style="--reveal-delay: {{ !empty($title) ? 240 : 0 }}ms">
+                <script id="CookieDeclaration" src="{{ $url }}" data-culture="NL" type="text/javascript" async></script>
+            </div>
+        @endif
+
+    </x-container>
+</section>


### PR DESCRIPTION
## Samenvatting

Voegt een nieuwe content-strip **"Cookieverklaring"** toe waarmee een redacteur in het
CMS de Cookiebot cookieverklaring op een pagina kan plaatsen. De strip heeft velden voor
een **subtitel**, **titel** en een **Cookiebot URL**, en rendert aan de voorkant met
dezelfde styling als de bestaande `TextStrip`.

De inhoud wordt geladen via het Cookiebot CookieDeclaration-script:

```html
<script id="CookieDeclaration" src="{url}" data-culture="NL" type="text/javascript" async></script>
```

De taal is vastgezet op Nederlands via het `data-culture="NL"`-attribuut.

## Waarom

De cookieverklaring kon nog niet vanuit het CMS op een pagina geplaatst worden. Een
script in een gewoon RichEditor-content-veld werkt niet: die content gaat door
`sanitizeHtml()` (Symfony `HtmlSanitizer`, `allowSafeElements()`), wat `<script>`-tags
verwijdert. Daarom is een dedicated strip nodig waarvan de blade-template het script-tag
rechtstreeks bevat (buiten de sanitizer om), zodat het in de browser wordt uitgevoerd.

## Wijzigingen

- **`app/Strips/CookieDeclarationStrip.php`** (nieuw) — strip-klasse die
  `ContentStrip` implementeert met `id()` → `cookie-declaration`, en een `block()`-schema
  met `subtitle`, `title` en een verplichte, gevalideerde `url` (Cookiebot src-URL).
- **`resources/views/strips/cookie-declaration.blade.php`** (nieuw) — blade-view met de
  `text-strip` styling (zelfde section/container/titel als `TextStrip`), een subtitel-eyebrow,
  en het `<script id="CookieDeclaration">`-tag met de geëscapete URL (`{{ $url }}`) en
  `data-culture="NL"`.
- **`config/made-cms.php`** — `CookieDeclarationStrip` geregistreerd onder
  `content.blocks.default`, zodat de strip op elk content-veld beschikbaar is.

## Veiligheid

- De URL komt uit een apart `TextInput` met `->url()`-validatie en wordt HTML-geëscaped
  in het `src`-attribuut via `{{ $url }}`.
- Het script-tag staat in de blade-template zelf en is daarmee onder controle van de
  applicatie, niet vrije gebruikersinvoer.